### PR TITLE
Mark this repo as a replacement for mongosoft/yii2-soap-client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
   "config": {
     "process-timeout": 1800
   },
+  "replace": {
+    "mongosoft/yii2-soap-client": "*"
+  },
   "repositories": [
     {
       "type": "composer",


### PR DESCRIPTION
Most popular Yii2 soap package is abandoned: https://packagist.org/packages/mongosoft/yii2-soap-client.

This repo seems to be almost compatible with it, so I want to mark it as a replacement.